### PR TITLE
mermaid: Fix DSDS reference to SS product.

### DIFF
--- a/aosp_i4213.mk
+++ b/aosp_i4213.mk
@@ -21,7 +21,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.telephony.default_network=9,0
 
 # Inherit from those products. Most specific first.
-$(call inherit-product, device/sony/mermaid/aosp_h3213.mk)
+$(call inherit-product, device/sony/mermaid/aosp_i3213.mk)
 
 PRODUCT_NAME := aosp_i4213
 PRODUCT_DEVICE := mermaid


### PR DESCRIPTION
The SS Mermaid variant is `i3213`, `h3113` is Pioneer (XA2) SS.

Signed-off-by: MarijnS95 <marijns95@gmail.com>