### PR TITLE
camera: Add config for s5k4h8

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -35,7 +35,8 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/etc/camera/camera_config.xml:$(TARGET_COPY_OUT_VENDOR)/etc/camera/camera_config.xml \
     $(DEVICE_PATH)/vendor/etc/camera/imx486_chromatix.xml:$(TARGET_COPY_OUT_VENDOR)/etc/camera/imx486_chromatix.xml \
-    $(DEVICE_PATH)/vendor/etc/camera/s5k4h7yx_chromatix.xml:$(TARGET_COPY_OUT_VENDOR)/etc/camera/s5k4h7yx_chromatix.xml
+    $(DEVICE_PATH)/vendor/etc/camera/s5k4h7yx_chromatix.xml:$(TARGET_COPY_OUT_VENDOR)/etc/camera/s5k4h7yx_chromatix.xml \
+    $(DEVICE_PATH)/vendor/etc/camera/s5k4h8_chromatix.xml:$(TARGET_COPY_OUT_VENDOR)/etc/camera/s5k4h8_chromatix.xml
 
 # Audio Configuration
 PRODUCT_COPY_FILES += \

--- a/rootdir/vendor/etc/camera/camera_config.xml
+++ b/rootdir/vendor/etc/camera/camera_config.xml
@@ -24,6 +24,30 @@
     </LensInfo>
   </CameraModuleConfig>
   <CameraModuleConfig>
+    <CameraId>1</CameraId>
+    <SensorName>s5k4h8</SensorName>
+    <ActuatorName>lc898214xc</ActuatorName>
+    <FlashName>pmic</FlashName>
+    <ChromatixName>s5k4h8_chromatix</ChromatixName>
+    <ModesSupported>1</ModesSupported>
+    <Position>BACK</Position>
+    <MountAngle>90</MountAngle>
+    <CSIInfo>
+      <CSIDCore>2</CSIDCore>
+      <LaneMask>0x1F</LaneMask>
+      <LaneAssign>0x4320</LaneAssign>
+      <ComboMode>0</ComboMode>
+    </CSIInfo>
+    <LensInfo>
+      <FocalLength>5.54</FocalLength>
+      <FNumber>2.4</FNumber>
+      <TotalFocusDistance>10</TotalFocusDistance>
+      <HorizontalViewAngle>36.4</HorizontalViewAngle>
+      <VerticalViewAngle>27.8</VerticalViewAngle>
+      <MinFocusDistance>0.5</MinFocusDistance>
+    </LensInfo>
+  </CameraModuleConfig>
+  <CameraModuleConfig>
     <CameraId>2</CameraId>
     <SensorName>s5k4h7yx</SensorName>
     <ChromatixName>s5k4h7yx_chromatix</ChromatixName>

--- a/rootdir/vendor/etc/camera/s5k4h8_chromatix.xml
+++ b/rootdir/vendor/etc/camera/s5k4h8_chromatix.xml
@@ -1,0 +1,21 @@
+<ChromatixConfigurationRoot>
+  <CommonChromatixInfo>
+    <ChromatixName>
+      <ISPCommon>s5k4h8_common</ISPCommon>
+      <PostProc>s5k4h8_postproc</PostProc>
+    </ChromatixName>
+  </CommonChromatixInfo>
+  <ResolutionChromatixInfo>
+    <ChromatixName sensor_resolution_index="0" special_mode_mask="0">
+      <ISPPreview>s5k4h8_snapshot</ISPPreview>
+      <ISPSnapshot>s5k4h8_snapshot</ISPSnapshot>
+      <ISPVideo>s5k4h8_video</ISPVideo>
+      <CPPPreview>s5k4h8_cpp_snapshot</CPPPreview>
+      <CPPSnapshot>s5k4h8_cpp_snapshot</CPPSnapshot>
+      <CPPLiveshot>s5k4h8_cpp_video</CPPLiveshot>
+      <CPPVideo>s5k4h8_cpp_video</CPPVideo>
+      <A3Preview>s5k4h8_zsl_preview</A3Preview>
+      <A3Video>s5k4h8_zsl_video</A3Video>
+    </ChromatixName>
+  </ResolutionChromatixInfo>
+</ChromatixConfigurationRoot>


### PR DESCRIPTION
Support for this camera module was included in the OEM blobs V8 but config was missing.
This PR adds the camera module in camera_config.xml, adds the required chromatix xml config that points to all the libraries in OEM and copies this file to actual vendor image